### PR TITLE
#10 — Commit WIP: cleanup & atomic commits

### DIFF
--- a/app/welcome/welcome.tsx
+++ b/app/welcome/welcome.tsx
@@ -71,7 +71,7 @@ export function Welcome({
             href={instagramUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="btn btn-secondary text-lg px-8 py-3 inline-flex items-center gap-2"
+            className="btn btn-secondary text-lg px-8 py-3 min-h-[44px] inline-flex items-center gap-2"
             aria-label="Seguir Roberta Furucho no Instagram (abre em nova aba)"
           >
             <svg 

--- a/backend/src/main/java/com/robertafurucho/whatsapp/NotificationService.java
+++ b/backend/src/main/java/com/robertafurucho/whatsapp/NotificationService.java
@@ -66,7 +66,7 @@ public class NotificationService {
     }
 
     private static String truncate(String value, int maxLength) {
-        if (value.length() <= maxLength) return value;
+        if (value == null || value.length() <= maxLength) return value;
         return value.substring(0, maxLength - 3) + "...";
     }
 }

--- a/backend/src/test/java/com/robertafurucho/whatsapp/NotificationServiceTest.java
+++ b/backend/src/test/java/com/robertafurucho/whatsapp/NotificationServiceTest.java
@@ -1,0 +1,176 @@
+package com.robertafurucho.whatsapp;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link NotificationService}.
+ *
+ * Covers:
+ * - Skip when WhatsApp disabled
+ * - Skip when robertaWaId blank/null
+ * - Happy-path message formatting
+ * - safe() null handling
+ * - truncate() at boundary and beyond
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("NotificationService")
+class NotificationServiceTest {
+
+    @Mock
+    private WhatsAppClient client;
+
+    @Mock
+    private WhatsAppConfig config;
+
+    @Mock
+    private WhatsAppConfig.Notification notificationConfig;
+
+    private NotificationService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new NotificationService(client, config);
+    }
+
+    @Nested
+    @DisplayName("notifyNewOrder()")
+    class NotifyNewOrder {
+
+        @Test
+        @DisplayName("skips notification when WhatsApp is disabled")
+        void skipsWhenDisabled() {
+            when(config.isEnabled()).thenReturn(false);
+            when(config.getNotification()).thenReturn(notificationConfig);
+            when(notificationConfig.getRobertaWaId()).thenReturn("5511999990000");
+
+            service.notifyNewOrder(1L, "Maria", "Boneca", "Detalhe");
+
+            verify(client, never()).sendText(anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("skips notification when robertaWaId is null")
+        void skipsWhenWaIdNull() {
+            when(config.isEnabled()).thenReturn(true);
+            when(config.getNotification()).thenReturn(notificationConfig);
+            when(notificationConfig.getRobertaWaId()).thenReturn(null);
+
+            service.notifyNewOrder(1L, "Maria", "Boneca", "Detalhe");
+
+            verify(client, never()).sendText(anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("skips notification when robertaWaId is blank")
+        void skipsWhenWaIdBlank() {
+            when(config.isEnabled()).thenReturn(true);
+            when(config.getNotification()).thenReturn(notificationConfig);
+            when(notificationConfig.getRobertaWaId()).thenReturn("   ");
+
+            service.notifyNewOrder(1L, "Maria", "Boneca", "Detalhe");
+
+            verify(client, never()).sendText(anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("sends formatted message to Roberta on happy path")
+        void sendsFormattedMessage() {
+            when(config.isEnabled()).thenReturn(true);
+            when(config.getNotification()).thenReturn(notificationConfig);
+            when(notificationConfig.getRobertaWaId()).thenReturn("5511999990000");
+
+            service.notifyNewOrder(42L, "Maria da Silva", "Bailarina",
+                    "Vestido azul com detalhes em prata");
+
+            ArgumentCaptor<String> msgCaptor = ArgumentCaptor.forClass(String.class);
+            verify(client).sendText(eq("5511999990000"), msgCaptor.capture());
+
+            String msg = msgCaptor.getValue();
+            assertThat(msg).contains("Novo pedido #42");
+            assertThat(msg).contains("Maria da Silva");
+            assertThat(msg).contains("Bailarina");
+            assertThat(msg).contains("Vestido azul com detalhes em prata");
+            assertThat(msg).contains("painel");
+        }
+
+        @Test
+        @DisplayName("handles null customer name with safe() fallback")
+        void handlesNullCustomerName() {
+            when(config.isEnabled()).thenReturn(true);
+            when(config.getNotification()).thenReturn(notificationConfig);
+            when(notificationConfig.getRobertaWaId()).thenReturn("5511999990000");
+
+            service.notifyNewOrder(1L, null, "Boneca", "Detalhe");
+
+            ArgumentCaptor<String> msgCaptor = ArgumentCaptor.forClass(String.class);
+            verify(client).sendText(eq("5511999990000"), msgCaptor.capture());
+
+            assertThat(msgCaptor.getValue()).contains("—");
+        }
+
+        @Test
+        @DisplayName("handles null orderScopeDetail with safe() fallback")
+        void handlesNullOrderScopeDetail() {
+            when(config.isEnabled()).thenReturn(true);
+            when(config.getNotification()).thenReturn(notificationConfig);
+            when(notificationConfig.getRobertaWaId()).thenReturn("5511999990000");
+
+            service.notifyNewOrder(1L, "Maria", "Boneca", null);
+
+            ArgumentCaptor<String> msgCaptor = ArgumentCaptor.forClass(String.class);
+            verify(client).sendText(eq("5511999990000"), msgCaptor.capture());
+
+            // safe(null) = "—", truncate("—", 200) → "—" (1 char ≤ 200)
+            assertThat(msgCaptor.getValue()).contains("—");
+        }
+
+        @Test
+        @DisplayName("truncates long orderScopeDetail to 200 chars with ellipsis")
+        void truncatesLongDetail() {
+            when(config.isEnabled()).thenReturn(true);
+            when(config.getNotification()).thenReturn(notificationConfig);
+            when(notificationConfig.getRobertaWaId()).thenReturn("5511999990000");
+
+            String longDetail = "A".repeat(250);
+            service.notifyNewOrder(1L, "Maria", "Boneca", longDetail);
+
+            ArgumentCaptor<String> msgCaptor = ArgumentCaptor.forClass(String.class);
+            verify(client).sendText(eq("5511999990000"), msgCaptor.capture());
+
+            String msg = msgCaptor.getValue();
+            // Truncated: first 197 chars + "..."
+            assertThat(msg).contains("A".repeat(197) + "...");
+            assertThat(msg).doesNotContain("A".repeat(198));
+        }
+
+        @Test
+        @DisplayName("does not truncate detail exactly at 200 chars")
+        void doesNotTruncateAtBoundary() {
+            when(config.isEnabled()).thenReturn(true);
+            when(config.getNotification()).thenReturn(notificationConfig);
+            when(notificationConfig.getRobertaWaId()).thenReturn("5511999990000");
+
+            String exactDetail = "B".repeat(200);
+            service.notifyNewOrder(1L, "Maria", "Boneca", exactDetail);
+
+            ArgumentCaptor<String> msgCaptor = ArgumentCaptor.forClass(String.class);
+            verify(client).sendText(eq("5511999990000"), msgCaptor.capture());
+
+            assertThat(msgCaptor.getValue()).contains("B".repeat(200));
+        }
+    }
+}

--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -9,7 +9,7 @@ Compliant with **WCAG 2.2 Level AA** (W3C Recommendation, October 2023).
 | ------ | ------------------------------------ | ----- | ----------------------------------------------- |
 | 2.4.11 | Focus Not Obscured (Minimum)         | AA    | ✅ No sticky overlays or modals that hide focus |
 | 2.5.7  | Dragging Movements                   | AA    | ✅ N/A — no drag-and-drop UI                    |
-| 2.5.8  | Target Size (Minimum)                | AA    | ✅ All interactive targets ≥ 44×44 CSS px       |
+| 2.5.8  | Target Size (Minimum)                | AA    | ✅ All interactive targets ≥ 44×44 via min-h/w     |
 | 3.2.6  | Consistent Help                      | A     | ✅ N/A — single-page app                        |
 | 3.3.7  | Redundant Entry                      | A     | ✅ N/A — single-step form                       |
 | 3.3.8  | Accessible Authentication (Minimum)  | AA    | ✅ N/A — no authentication                      |

--- a/e2e/a11y.spec.ts
+++ b/e2e/a11y.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
+import { futureDate } from './helpers';
 
 /**
  * E2E — Keyboard navigation & accessibility audit (Batch 4B).
@@ -127,15 +128,7 @@ test.describe('Keyboard & accessibility', () => {
     await page.keyboard.type('Cabelo loiro, vestido azul');
 
     await page.keyboard.press('Tab');
-
-    const futureDate = (() => {
-      const d = new Date();
-      d.setMonth(d.getMonth() + 6);
-      const dd = String(d.getDate()).padStart(2, '0');
-      const mm = String(d.getMonth() + 1).padStart(2, '0');
-      return `${dd}/${mm}/${d.getFullYear()}`;
-    })();
-    await page.keyboard.type(futureDate);
+    await page.keyboard.type(futureDate());
 
     // Tab to submit button and press Enter
     await page.keyboard.press('Tab');
@@ -164,6 +157,12 @@ test.describe('Keyboard & accessibility', () => {
   // 4B.6 — WCAG 2.2 SC 2.5.8 Target Size (Minimum) ≥ 24×24 CSS px
   test('interactive elements meet 24×24 minimum target size (WCAG 2.5.8)', async ({ page }) => {
     const MIN = 24;
+
+    // Brand link
+    const brandLink = page.getByRole('link', { name: 'Roberta Furucho', exact: true });
+    const brandBox = await brandLink.boundingBox();
+    expect(brandBox, 'Brand link has bounding box').toBeTruthy();
+    expect(brandBox!.height).toBeGreaterThanOrEqual(MIN);
 
     // Header nav links
     for (const name of ['Início', 'Encomendas']) {

--- a/e2e/happy-path.spec.ts
+++ b/e2e/happy-path.spec.ts
@@ -1,13 +1,5 @@
 import { test, expect } from '@playwright/test';
-
-/** Returns a date 6 months from now as DD/MM/YYYY. */
-function futureDate(): string {
-  const d = new Date();
-  d.setMonth(d.getMonth() + 6);
-  const dd = String(d.getDate()).padStart(2, '0');
-  const mm = String(d.getMonth() + 1).padStart(2, '0');
-  return `${dd}/${mm}/${d.getFullYear()}`;
-}
+import { futureDate } from './helpers';
 
 /**
  * E2E — Happy path & validation (Batch 4A).

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,18 @@
+/**
+ * E2E test helpers — shared utilities for Playwright specs.
+ */
+
+/**
+ * Returns a date string 6 months from now as DD/MM/YYYY.
+ *
+ * Uses the same offset across all E2E specs that need future dates.
+ * The unit-test factory (orderFactory.ts) uses 90 days — both are
+ * safely beyond any minimum-date validation in the form.
+ */
+export function futureDate(): string {
+  const d = new Date();
+  d.setMonth(d.getMonth() + 6);
+  const dd = String(d.getDate()).padStart(2, '0');
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  return `${dd}/${mm}/${d.getFullYear()}`;
+}

--- a/src/component/Header/Header.tsx
+++ b/src/component/Header/Header.tsx
@@ -38,7 +38,7 @@ export function Header({
           {/* Brand */}
           <a 
             href="/" 
-            className="text-xl font-bold hover:opacity-80 transition-opacity"
+            className="inline-flex items-center min-h-[44px] text-xl font-bold hover:opacity-80 transition-opacity"
             style={{ color: 'var(--color-text-heading)' }}
           >
             Roberta Furucho


### PR DESCRIPTION
## Summary
Organizes uncommitted WIP on `chatbot-improvements` into clean atomic commits.

### Commits
1. **a11y: enforce min-h-[44px] target size** — WCAG 2.5.8 compliance on Instagram CTA and brand link
2. **e2e: extract shared futureDate helper** — DRY refactor + brand link target size test
3. **feat(backend): NotificationService** — WhatsApp order alerts to Roberta (8 unit tests)

### Cleanup
- Deleted junk file `docs/"mcp": {.json`
- Unstaged accidental `backend/target/` deletions

Closes #10